### PR TITLE
#4 Refactor feedback handling with FeedbackWrapper class

### DIFF
--- a/FeedbackHub/FeedbackHub/ViewModel/Wrappers/FeedbackWrapper.cs
+++ b/FeedbackHub/FeedbackHub/ViewModel/Wrappers/FeedbackWrapper.cs
@@ -1,0 +1,37 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using FeedbackHub.Model.Entities;
+
+namespace FeedbackHub.ViewModel.Wrappers
+{
+    public partial class FeedbackWrapper : ObservableObject
+    {
+        [ObservableProperty] private int _id;
+        [ObservableProperty] private int _rating;
+        [ObservableProperty] private string? _note;
+        [ObservableProperty] private DateTime? _createdAt;
+        [ObservableProperty] private DateTime? _modifiedAt;
+
+        public FeedbackWrapper()
+        {
+
+        }
+
+        public FeedbackWrapper(Feedback feedback)
+        {
+            Id = feedback.Id;
+            Rating = feedback.Rating;
+            Note = feedback.Note;
+            CreatedAt = feedback.CreatedAt;
+            ModifiedAt = feedback.ModifiedAt;
+        }
+
+        public Feedback ConvertToModel() => new()
+        {
+            Id = Id,
+            Rating = Rating,
+            Note = Note,
+            CreatedAt = CreatedAt,
+            ModifiedAt = ModifiedAt
+        };
+    }
+}


### PR DESCRIPTION
Updated MainWindowViewModel to utilize FeedbackWrapper instead of Feedback. Properties Rating and Note now trigger updates to Result. Modified Create, Modify, and Delete methods to work with FeedbackWrapper instances. Introduced GetResultMessage method for formatted output. Created FeedbackWrapper class to facilitate data binding and conversion to the original Feedback model.